### PR TITLE
Update to R18 monotonic time

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,9 +2,9 @@
 %% Config file for can-application
 {require_min_otp_vsn, "R18"}.
 
-{deps, [{dthread, ".*", {git, "https://github.com/tonyrog/dthread.git"}},
-	{uart, ".*", {git, "https://github.com/tonyrog/uart.git"}},
-	{lager, ".*", {git, "https://github.com/basho/lager.git"}}
+{deps, [{dthread, ".*", {git, "https://github.com/tonyrog/dthread.git", {branch, master}}},
+	{uart, ".*", {git, "https://github.com/tonyrog/uart.git", {branch, master}}},
+	{lager, ".*", {git, "https://github.com/basho/lager.git", {branch, master}}}
        ]}.
 {erl_opts, [debug_info, fail_on_warning, {parse_transform, lager_transform}]}.
 {sub_dirs, ["src"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 %% -*- erlang -*-
 %% Config file for can-application
+{require_min_otp_vsn, "R18"}.
 
 {deps, [{dthread, ".*", {git, "https://github.com/tonyrog/dthread.git"}},
 	{uart, ".*", {git, "https://github.com/tonyrog/uart.git"}},

--- a/src/can_probe.erl
+++ b/src/can_probe.erl
@@ -48,7 +48,7 @@ init(Opts) ->
 	Time -> erlang:start_timer(Time, self(), done)
     end,
     MaxFrames = proplists:get_value(max_frame, Opts, -1),
-    T0 = now(),
+    T0 = erlang:monotonic_time(),
     loop(T0, MaxFrames).
 
 loop(_T, 0) ->
@@ -56,7 +56,7 @@ loop(_T, 0) ->
 loop(T0, FrameCount) ->
     receive
 	Frame = #can_frame {} ->
-	    print_frame(timer:now_diff(now(),T0), Frame),
+	    print_frame(erlang:monotonic_time() - T0, Frame),
 	    loop(T0, FrameCount - 1);
 	{timeout, _Ref, done} ->
 	    ok;


### PR DESCRIPTION
The new time primitives in R18 have better performance and clearer semantics. The changes required are minor, but it does mean raising the minimum OTP version to R18. I've updated the rebar.config to reflect this, as well as adding explicit branches for the deps.
